### PR TITLE
Fixes "PHP Warning: Trying to access array offset on value of type bool"

### DIFF
--- a/acf-user-role-field-setting.php
+++ b/acf-user-role-field-setting.php
@@ -44,7 +44,7 @@
 		
 		private function user_can_edit($field) {
 			$exclude = apply_filters('acf/user_role_setting/exclude_field_types', $this->exclude_field_types);
-			if (in_array($field['type'], $exclude)) {
+			if (isset($field['type']) && is_array($exclude) && in_array($field['type'], $exclude)) {
 				return true;
 			}
 			if (isset($field['user_roles'])) {


### PR DESCRIPTION
Full log line: `PHP Warning:  Trying to access array offset on value of type bool in /path/to/wp-content/plugins/user-role-field-setting-for-acf/acf-user-role-field-setting.php on line 47`