### PR TITLE
Does not show the user role options apparently because of the last change in line 124, tested with acf v. 6.0.6

### DIFF
--- a/acf-user-role-field-setting.php
+++ b/acf-user-role-field-setting.php
@@ -121,7 +121,7 @@
 			} else {
 				// >= 5.5.0 || < 5.6.0
 				foreach ($sections as $type => $settings) {
-					if ( !isset( $exclude[$type] ) || !empty($exclude[$type])) {
+					if (empty($exclude[$type])) {
 						add_action('acf/render_field_settings/type='.$type, array($this, 'render_field_settings'), 1);
 					}
 				}

--- a/acf-user-role-field-setting.php
+++ b/acf-user-role-field-setting.php
@@ -121,7 +121,7 @@
 			} else {
 				// >= 5.5.0 || < 5.6.0
 				foreach ($sections as $type => $settings) {
-					if (!empty($exclude[$type])) {
+					if ( !isset( $exclude[$type] ) || !empty($exclude[$type])) {
 						add_action('acf/render_field_settings/type='.$type, array($this, 'render_field_settings'), 1);
 					}
 				}


### PR DESCRIPTION
After upgrading to the latest version I noticed that all the user role options disappeared. The change I made was to solve that bug. 