### PR TITLE
🐛 FIX: COMPOSER: Can't install through composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Hube2/acf-user-role-field-setting",
+  "name": "hube2/acf-user-role-field-setting",
   "description": "acf-user-role-field-setting",
   "type": "wordpress-plugin",
   "authors": [


### PR DESCRIPTION
Hi,

A little patch to allow the installation of the plugin through composer.

The vendor name should be in lowercase only.

Thanks